### PR TITLE
added jvm system property

### DIFF
--- a/project/ScalazBuild.scala
+++ b/project/ScalazBuild.scala
@@ -72,6 +72,7 @@ object Scalaz {
       s"-Dpartest.root=${(baseDirectory in LocalProject("tests")).value}",
       s"-Dpartest.exec.in.process=true",
       s"-Dscalaz.plugin.jar=${(packageBin in Compile in LocalProject("plugin")).value}",
+      s"-Duser.country=US",
     ),
     testFrameworks += new TestFramework("scala.tools.partest.sbt.Framework"),
     definedTests in Test +=


### PR DESCRIPTION
System property `user.country` hard-coded to `US`.

In order to resolve following exception while running `partest`:
```
[error] Caused by: sbt.ForkMain$ForkError: java.lang.AssertionError: assertion failed: 
Unable to run test without forking as the current JVM has an incorrect system property. 
For user.country, found IN, required US
```