### PR TITLE
Added Plugin.init.

### DIFF
--- a/plugin/src/main/scala/scalaz/meta/plugin/MetaPlugin.scala
+++ b/plugin/src/main/scala/scalaz/meta/plugin/MetaPlugin.scala
@@ -7,9 +7,8 @@ class MetaPlugin(val global: Global) extends Plugin { plugin =>
   val name        = "scalaz"
   val description = "scalaz"
 
-  override def init(options: List[String], error: String => Unit): Boolean = {
+  override def init(options: List[String], error: String => Unit): Boolean =
     true
-  }
 
   val scalazDefns = new {
     val global: plugin.global.type = plugin.global

--- a/plugin/src/main/scala/scalaz/meta/plugin/MetaPlugin.scala
+++ b/plugin/src/main/scala/scalaz/meta/plugin/MetaPlugin.scala
@@ -7,6 +7,10 @@ class MetaPlugin(val global: Global) extends Plugin { plugin =>
   val name        = "scalaz"
   val description = "scalaz"
 
+  override def init(options: List[String], error: String => Unit): Boolean = {
+    true
+  }
+
   val scalazDefns = new {
     val global: plugin.global.type = plugin.global
   } with Definitions


### PR DESCRIPTION
Otherwise plugin options do not work, since `Plugin` defines:
```scala
  def init(options: List[String], error: String => Unit): Boolean = {
    // call to deprecated method required here, we must continue to support
    // code that subclasses that override `processOptions`.
    processOptions(options, error)
    true
  }

  @deprecated("use Plugin#init instead", since="2.11.0")
  def processOptions(options: List[String], error: String => Unit): Unit = {
    if (!options.isEmpty) error(s"Error: $name takes no options")
  }
```