### PR TITLE
Cross-build 2.12.4 and 2.12.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,11 @@ jobs:
 #      - git config --global push.default simple
 #      - sbt ++${TRAVIS_SCALA_VERSION}! microsite/publishMicrosite
 
+    # Cross-build
+    - <<: *build
+      scala: 2.12.4
+      name: "Build with 2.12.4"
+
 cache:
   directories:
   - $HOME/.sbt/1.0/dependency

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,7 @@ cancelable in Global := true
 
 inThisBuild(
   List(
+    crossScalaVersions := List("2.12.6", "2.12.4"),
     organization := "org.scalaz",
     homepage := Some(url("https://github.com/scalaz/scalaz-plugin")),
     licenses := List("LGPL 3.0" -> url("https://www.gnu.org/licenses/lgpl-3.0.en.html")),


### PR DESCRIPTION
This should allow the plugin to be cross-built/published.

`ci-release` should automatically use all `crossScalaVersion` entries.
We are currently actually testing with 2.12.6 but publishing with 2.12.4 :D