### PR TITLE
repl command for sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,10 @@ lazy val tests = (project in file("test"))
     )
   )
 
-commands in Global += Commandz.partestCommand(baseDirectory.value)
+commands in Global ++= List(
+  Commandz.partestCommand(baseDirectory.value),
+  Commandz.replCommand,
+)
 
 lazy val exampleJVM = example.jvm
 lazy val exampleJS  = example.js

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -65,4 +65,26 @@ object Commandz {
     }
   }
 
+  /** A command to launch the repl with given args and the plugin enabled.
+    */
+  val replCommand: Command =
+    Command.args("repl", "<scalac args>") { (state, args) =>
+      import Keys.{state => _, _}
+      val extracted = Project.extract(state)
+      val (state1, cp) =
+        extracted.runTask(fullClasspath in Compile in LocalProject("plugin"), state)
+      val (state2, pluginJar) =
+        extracted.runTask(packageBin in Compile in LocalProject("plugin"), state1)
+      // for some reason we need to add the classpath here... passing it to the
+      // `runner` below lets us load scalac but nothing else (even with -usejavacp)
+      val scalacOpts =
+        "-cp" :: cp.map(_.data).mkString(":") :: s"-Xplugin:$pluginJar" :: args.toList
+
+      val log = extracted.get(sLog) // wrong logger, but works
+      val (state3, runner) = extracted.runTask(Keys.runner in LocalProject("plugin"), state2)
+      runner.run("scala.tools.nsc.MainGenericRunner", cp.map(_.data), scalacOpts, log)
+        .get
+
+      state3
+    }
 }

--- a/project/Commands.scala
+++ b/project/Commands.scala
@@ -66,10 +66,10 @@ object Commandz {
   }
 
   /** A command to launch the repl with given args and the plugin enabled.
-    */
+   */
   val replCommand: Command =
     Command.args("repl", "<scalac args>") { (state, args) =>
-      import Keys.{state => _, _}
+      import Keys.{ state => _, _ }
       val extracted = Project.extract(state)
       val (state1, cp) =
         extracted.runTask(fullClasspath in Compile in LocalProject("plugin"), state)
@@ -80,10 +80,9 @@ object Commandz {
       val scalacOpts =
         "-cp" :: cp.map(_.data).mkString(":") :: s"-Xplugin:$pluginJar" :: args.toList
 
-      val log = extracted.get(sLog) // wrong logger, but works
+      val log              = extracted.get(sLog) // wrong logger, but works
       val (state3, runner) = extracted.runTask(Keys.runner in LocalProject("plugin"), state2)
-      runner.run("scala.tools.nsc.MainGenericRunner", cp.map(_.data), scalacOpts, log)
-        .get
+      runner.run("scala.tools.nsc.MainGenericRunner", cp.map(_.data), scalacOpts, log).get
 
       state3
     }


### PR DESCRIPTION
works better than `plugin/test:console` because that seems to cache scalac instances too hard. also, this lets you pass options.